### PR TITLE
cairo_venv updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,18 @@ cd 10k_swap-contracts
 ```
 yarn install
 ```
+#### check if cairo_venv exixts?
+```
+ls -la cairo_venv
 
+```
+### if not then run the following commands
+```
+python3 -m venv cairo_venv  # Create a virtual environment
+source cairo_venv/bin/activate  # Activate it
+pip install cairo-lang  # Install Cairo
+
+```
 #### Compile a contract
 
 ```


### PR DESCRIPTION
This issue came while running
npx hardhat starknet-compile contracts/l0k_factory.cairo

I have added its solution in Readme.md file
1️⃣ Check if cairo_venv exists

Run:
ls -la cairo_venv

If the folder does not exist, you need to create it.

python3 -m venv cairo_venv  # Create a virtual environment
source cairo_venv/bin/activate  # Activate it
pip install cairo-lang  # Install Cairo

